### PR TITLE
Gas-liquid momentum exchange term (Equation 4)

### DIFF
--- a/applications/solvers/multiphase/multiphaseEulerFoam/interfacialModels/dragModels/AttouFerschneider/AttouFerschneider.C
+++ b/applications/solvers/multiphase/multiphaseEulerFoam/interfacialModels/dragModels/AttouFerschneider/AttouFerschneider.C
@@ -58,7 +58,7 @@ Foam::dragModels::AttouFerschneider::KGasLiquid
     const volScalarField magURel(mag(gas.U() - liquid.U()));
 
     return
-        E2_*gas.thermo().mu()*sqr(oneMinusGas/solid.d())*sqr(cbrtR)
+        E1_*gas.thermo().mu()*sqr(oneMinusGas/solid.d())*sqr(cbrtR)
        /max(gas, gas.residualAlpha())
       + E2_*gas.rho()*magURel*(1 - gas)/solid.d()*cbrtR;
 }


### PR DESCRIPTION
I was working on developing a drag model when I came across the Attou and Frescheinder model. The implemented equation for the Gas-liquid momentum exchange term seems to be different than that reported by the authors.

See the original equation (Equation 4 in the paper):

$$ F_{GL} = \epsilon_G \left( \frac{E_1\mu_G(1-\epsilon_G)^2}{\epsilon_G^2d_p^2} \left( \frac{\epsilon_S}{1-\epsilon_G} \right)^{0.667} +\frac{E_2\rho_G(U_G-U_L)(1-\epsilon_G)}{\epsilon_Gd_p} \left( \frac{\epsilon_S}{1-\epsilon_G} \right)^{0.333}  \right) $$

Could it be that there is a mistake on its implementation?

Reference from the header file: 

- **Gunjal, P. R., & Ranade, V. V. (2007)**. Modeling of laboratory and commercial scale hydro-processing reactors using CFD. _Chemical Engineering Science, 62(18-20), 5512-5526_.